### PR TITLE
Use SubscriptionId to dispatch messages to handlers internally, fixes #47

### DIFF
--- a/src/MyNatsClient/NatsClient.cs
+++ b/src/MyNatsClient/NatsClient.cs
@@ -608,7 +608,7 @@ namespace MyNatsClient
         {
             var subscription = Subscription.Create(
                 subscriptionInfo,
-                subscriptionFactory(MsgOpStream.Where(msg => subscriptionInfo.Matches(msg.Subject))),
+                subscriptionFactory(MsgOpStream.Where(msg => msg.SubscriptionId == subscriptionInfo.Id)),
                 DisposeSubscription);
 
             if (!_subscriptions.TryAdd(subscription.SubscriptionInfo.Id, subscription))


### PR DESCRIPTION
Use `SubscriptionId` to dispatch messages to handlers internally, rather than matching on the subject, fixes #47.

If multiple subscriptions existed that had overlapping subjects, either through wildcards or explicit matches, then each message received for each subscription would get dispatched to every subscription (N^2).

Given:
    - `sidA = Sub("a.b", OnX)`
    - `sidB = Sub("a.*", OnY)`
    - `Pub("a.b", ...)`

MyNatsClient would receive:
    - `sidA a.b <payload>`
    - `sidB a.b <payload>`

And dispatch:
    - `OnX(sidA, a.b, payload)`
    - `OnY(sidA, a.b, payload)`
    - `OnX(sidB, a.b, payload)`
    - `OnY(sidB, a.b, payload)`

With this fix, MyNatsClient will dispatch:
    - `OnX(sidA, a.b, payload)`
    - `OnY(sidB, a.b, payload)`

Unit tests pass and the integration tests pass (I did not run Auth or TLS).