### PR TITLE
Send PINGs when server is silent for the configured duration #49

### DIFF
--- a/src/IntegrationTests/PubSubTests.cs
+++ b/src/IntegrationTests/PubSubTests.cs
@@ -211,5 +211,54 @@ namespace IntegrationTests
 
             _sync.InterceptedCount.Should().Be(2);
         }
+
+        [Fact]
+        public async Task Client_Should_throw_if_pub_when_never_connected()
+        {
+            var subject = Context.GenerateSubject();
+            var body = new byte[0];
+
+            _client1 = Context.CreateClient();
+
+            Assert.Throws<InvalidOperationException>(() => _client1.Pub(subject, "body"));
+            Assert.Throws<InvalidOperationException>(() => _client1.Pub(subject, "body", "reply.to.subject"));
+            Assert.Throws<InvalidOperationException>(() => _client1.Pub(subject, body.AsMemory()));
+            Assert.Throws<InvalidOperationException>(() => _client1.Pub(subject, body.AsMemory(), "reply.to.subject"));
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await _client1.PubAsync(subject, "body"));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await _client1.PubAsync(subject, "body", "reply.to.subject"));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await _client1.PubAsync(subject, body.AsMemory()));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await _client1.PubAsync(subject, body.AsMemory(), "reply.to.subject"));
+        }
+
+        [Fact]
+        public async Task Client_Should_throw_if_pub_after_disconnected()
+        {
+            var subject = Context.GenerateSubject();
+            var body = new byte[0];
+
+            _client1 = await Context.ConnectClientAsync();
+
+            // Succeeds
+            _client1.Pub(subject, "body");
+            _client1.Pub(subject, "body", "repy.to.subject");
+            _client1.Pub(subject, body.AsMemory());
+            _client1.Pub(subject, body.AsMemory(), "repy.to.subject");
+
+            // Disconnect from NATS per user request
+            _client1.Disconnect();
+            Assert.False(_client1.IsConnected);
+
+            // Fails after being disconnected
+            Assert.Throws<InvalidOperationException>(() => _client1.Pub(subject, "body"));
+            Assert.Throws<InvalidOperationException>(() => _client1.Pub(subject, "body", "reply.to.subject"));
+            Assert.Throws<InvalidOperationException>(() => _client1.Pub(subject, body.AsMemory()));
+            Assert.Throws<InvalidOperationException>(() => _client1.Pub(subject, body.AsMemory(), "reply.to.subject"));
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await _client1.PubAsync(subject, "body"));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await _client1.PubAsync(subject, "body", "reply.to.subject"));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await _client1.PubAsync(subject, body.AsMemory()));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await _client1.PubAsync(subject, body.AsMemory(), "reply.to.subject"));
+        }
     }
 }

--- a/src/IntegrationTests/RequestTests.cs
+++ b/src/IntegrationTests/RequestTests.cs
@@ -193,5 +193,47 @@ namespace IntegrationTests
 
             a.Should().Throw<TaskCanceledException>();
         }
+
+
+        [Fact]
+        public async Task Client_Should_throw_if_request_when_never_connected()
+        {
+            var subject = Context.GenerateSubject();
+            var body = new byte[0];
+
+            _requester = Context.CreateClient();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await _requester.RequestAsync(subject, "body"));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await _requester.RequestAsync(subject, body.AsMemory()));
+        }
+
+        [Fact]
+        public async Task Client_Should_throw_if_request_after_disconnected()
+        {
+            var subject = Context.GenerateSubject();
+            var body = new byte[0];
+
+            _responder = await Context.ConnectClientAsync();
+            _requester = await Context.ConnectClientAsync();
+
+            _responder.Sub(subject, stream => stream.Subscribe(msg => _responder.Pub(msg.ReplyTo, msg.GetPayloadAsString())));
+
+            await Context.DelayAsync();
+
+            // Succeeds
+            var response = await _requester.RequestAsync(subject, "body");
+            Assert.NotNull(response);
+
+            response = await _requester.RequestAsync(subject, body.AsMemory());
+            Assert.NotNull(response);
+
+            // Disconnect from NATS per user request
+            _requester.Disconnect();
+            Assert.False(_requester.IsConnected);
+
+            // Fails after being disconnected
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await _requester.RequestAsync(subject, "body"));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await _requester.RequestAsync(subject, body.AsMemory()));
+        }
     }
 }

--- a/src/MyNatsClient/Internals/DisconnectedConnection.cs
+++ b/src/MyNatsClient/Internals/DisconnectedConnection.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace MyNatsClient.Internals
+{
+    /// <summary>
+    /// Represents the state where MyNatsClient is disconnected, either through
+    /// server failure or client action.
+    /// </summary>
+    internal sealed class DisconnectedConnection : INatsConnection
+    {
+        public static readonly INatsConnection Instance = new DisconnectedConnection();
+
+        public bool IsConnected => false;
+
+        public bool CanRead => false;
+
+        public INatsServerInfo ServerInfo => throw NotConnected();
+        public IEnumerable<IOp> ReadOp() => throw NotConnected();
+        public void WithWriteLock(Action<INatsStreamWriter> a) => throw NotConnected();
+        public void WithWriteLock<TArg>(Action<INatsStreamWriter, TArg> a, TArg arg) => throw NotConnected();
+        public Task WithWriteLockAsync(Func<INatsStreamWriter, Task> a) => throw NotConnected();
+        public Task WithWriteLockAsync<TArg>(Func<INatsStreamWriter, TArg, Task> a, TArg arg) => throw NotConnected();
+
+        public void Dispose() { }
+
+        private static InvalidOperationException NotConnected() => new InvalidOperationException("Connection has been disconnected.");
+    }
+}

--- a/src/MyNatsClient/NatsClient.cs
+++ b/src/MyNatsClient/NatsClient.cs
@@ -227,9 +227,6 @@ namespace MyNatsClient
                 }
                 catch (Exception ex)
                 {
-                    if (!ShouldDoWork())
-                        break;
-
                     _logger.Error("Worker got Exception.", ex);
 
                     if (ex.InnerException is SocketException socketEx)
@@ -242,6 +239,9 @@ namespace MyNatsClient
                         if (socketEx.SocketErrorCode != SocketError.TimedOut)
                             throw;
                     }
+
+                    if (!ShouldDoWork())
+                        break;
 
                     var silenceDeltaMs = DateTime.UtcNow.Subtract(lastOpReceivedAt).TotalMilliseconds;
                     if (silenceDeltaMs >= ConsumerMaxMsSilenceFromServer)

--- a/src/MyNatsClient/NatsClient.cs
+++ b/src/MyNatsClient/NatsClient.cs
@@ -44,7 +44,7 @@ namespace MyNatsClient
         public INatsObservable<IClientEvent> Events => _eventMediator;
         public INatsObservable<IOp> OpStream => _opMediator.AllOpsStream;
         public INatsObservable<MsgOp> MsgOpStream => _opMediator.MsgOpsStream;
-        public bool IsConnected => _connection != null && _connection.IsConnected && _connection.CanRead;
+        public bool IsConnected => _connection.IsConnected && _connection.CanRead;
 
         public NatsClient(ConnectionInfo connectionInfo, ISocketFactory socketFactory = null)
         {
@@ -56,6 +56,7 @@ namespace MyNatsClient
             _inboxAddress = $"IB.{Id}";
             _sync = new SemaphoreSlim(1, 1);
             _connectionInfo = connectionInfo.Clone();
+            _connection = DisconnectedConnection.Instance;
             _subscriptions = new ConcurrentDictionary<string, Subscription>(StringComparer.OrdinalIgnoreCase);
             _eventMediator = new NatsObservableOf<IClientEvent>();
             _opMediator = new NatsOpMediator();
@@ -303,8 +304,8 @@ namespace MyNatsClient
             },
             () =>
             {
-                _connection?.Dispose();
-                _connection = null;
+                _connection.Dispose();
+                _connection = DisconnectedConnection.Instance;
             });
 
         public void Flush()

--- a/src/MyNatsClient/NatsClient.cs
+++ b/src/MyNatsClient/NatsClient.cs
@@ -204,10 +204,9 @@ namespace MyNatsClient
         {
             bool ShouldDoWork() => !_isDisposed && IsConnected && _cancellation?.IsCancellationRequested == false;
 
+            var lastOpReceivedAt = DateTime.UtcNow;
             while (ShouldDoWork())
             {
-                var lastOpReceivedAt = DateTime.UtcNow;
-
                 try
                 {
                     foreach (var op in _connection.ReadOp())


### PR DESCRIPTION
If a socket read times out the worker loop restarts. Restarting the worker loop causes `lastOpReceivedAt` to be reset. If the socket reads continually time out because no data has been received for some time, the tests for `ConsumerMaxMsSilenceFromServer` and `ConsumerPingAfterMsSilenceFromServer` will never be met.

This moves the initial assignment to `lastOpReceivedAt` to outside the worker's main loop, which enables the server silence calculations to succeed. Fixes #49.

In practice the issue looks like a slew of log entries with no PING emitted from the client:
```
MyNatsClient.NatsClient.Error: Worker task got SocketException with SocketErrorCode='TimedOut'
```