### PR TITLE
Stabilizes worker

### DIFF
--- a/src/IntegrationTests/Should.cs
+++ b/src/IntegrationTests/Should.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MyNatsClient;
+
+namespace IntegrationTests
+{
+    internal static class Should
+    {
+        internal static void ThrowNatsException(Action a)
+            => a.Should().ThrowExactly<NatsException>().Where(ex => ex.ExceptionCode == NatsExceptionCodes.NotConnected);
+
+        internal static async Task ThrowNatsExceptionAsync(Func<Task> a) =>
+            (await a.Should().ThrowExactlyAsync<NatsException>()).Where(ex => ex.ExceptionCode == NatsExceptionCodes.NotConnected);
+    }
+}

--- a/src/MyNatsClient/Internals/NatsConnection.cs
+++ b/src/MyNatsClient/Internals/NatsConnection.cs
@@ -187,7 +187,7 @@ namespace MyNatsClient.Internals
         private void ThrowIfNotConnected()
         {
             if (!IsConnected)
-                throw new InvalidOperationException("Connection has been disconnected.");
+                throw NatsException.NotConnected();
         }
     }
 }

--- a/src/MyNatsClient/NatsException.cs
+++ b/src/MyNatsClient/NatsException.cs
@@ -14,7 +14,8 @@ namespace MyNatsClient
         }
 
         internal static NatsException MissingCredentials(Host host)
-            => new NatsException(NatsExceptionCodes.MissingCredentials, $"Error while connecting to {host}. Host requires credentials to be passed. None was specified. Pass credentials for specific host or for all hosts.");
+            => new NatsException(NatsExceptionCodes.MissingCredentials,
+                $"Error while connecting to {host}. Host requires credentials to be passed. None was specified. Pass credentials for specific host or for all hosts.");
 
         internal static NatsException MissingClientCertificates(Host host)
             => new NatsException(NatsExceptionCodes.MissingClientCertificates, $"Error while connecting to {host}. Host requires client certificates. None was specified.");
@@ -29,10 +30,12 @@ namespace MyNatsClient
             => new NatsException(NatsExceptionCodes.ExceededMaxPayload, $"Server indicated max payload of {maxPayload} bytes. Current dispatch is {bufferLength} bytes.");
 
         internal static NatsException CouldNotCreateSubscription(SubscriptionInfo subscriptionInfo)
-            => new NatsException(NatsExceptionCodes.CouldNotCreateSubscription, $"Could not create subscription. Id='{subscriptionInfo.Id}'. Subject='{subscriptionInfo.Subject}' QueueGroup='{subscriptionInfo.QueueGroup}'.");
+            => new NatsException(NatsExceptionCodes.CouldNotCreateSubscription,
+                $"Could not create subscription. Id='{subscriptionInfo.Id}'. Subject='{subscriptionInfo.Subject}' QueueGroup='{subscriptionInfo.QueueGroup}'.");
 
         internal static NatsException ConnectionFoundIdling(string host, int port)
-            => new NatsException(NatsExceptionCodes.ConnectionFoundIdling, $"The Connection against server {host}:{port.ToString()} has not received any data in a to long period.");
+            => new NatsException(NatsExceptionCodes.ConnectionFoundIdling,
+                $"The Connection against server {host}:{port.ToString()} has not received any data in a to long period.");
 
         internal static NatsException ClientReceivedErrOp(ErrOp errOp)
             => new NatsException(NatsExceptionCodes.ClientReceivedErrOp, $"Client received ErrOp with message='{errOp.Message}'.");
@@ -50,6 +53,9 @@ namespace MyNatsClient
             => new NatsException(NatsExceptionCodes.OpParserOpParsingError, $"Error while parsing {op}. {message}");
 
         internal static NatsException InitRequestError(string message)
-        => new NatsException(NatsExceptionCodes.InitRequestError, message);
+            => new NatsException(NatsExceptionCodes.InitRequestError, message);
+
+        internal static NatsException NotConnected()
+            => new NatsException(NatsExceptionCodes.NotConnected, "No connection exists.");
     }
 }

--- a/src/MyNatsClient/NatsExceptionCodes.cs
+++ b/src/MyNatsClient/NatsExceptionCodes.cs
@@ -15,5 +15,6 @@ namespace MyNatsClient
         public const string OpParserOpParsingError = "OpParser.Error";
         public const string OpParserUnsupportedOp = "OpParser.UnsupportedOp";
         public const string InitRequestError = "Client.InitRequestError";
+        public const string NotConnected = "NotConnected";
     }
 }


### PR DESCRIPTION
  - Adds tests and some fixes from #50
  - Move state of lastOpReceivedAt to not be reset
  - Safely auto ping on silence
  - On ErrOp it should go into optional reconnect mode
  - Safe release resources if the worker exits
  - Ensure disconnected event is always raised