### PR TITLE
Add PubManyAsync

### DIFF
--- a/src/main/MyNatsClient/INatsClient.cs
+++ b/src/main/MyNatsClient/INatsClient.cs
@@ -138,6 +138,14 @@ namespace MyNatsClient
         void PubMany(Action<IPublisher> p);
 
         /// <summary>
+        /// Gives access to a publisher that will be running in
+        /// an async locked scope until your injected delegate
+        /// is done.
+        /// </summary>
+        /// <param name="p"></param>
+        Task PubManyAsync(Func<IPublisher, Task> p);
+
+        /// <summary>
         /// Async request response.
         /// </summary>
         /// <param name="subject"></param>

--- a/src/main/MyNatsClient/NatsClient.cs
+++ b/src/main/MyNatsClient/NatsClient.cs
@@ -467,6 +467,20 @@ namespace MyNatsClient
             });
         }
 
+        public async Task PubManyAsync(Func<IPublisher, Task> p)
+        {
+            ThrowIfDisposed();
+
+            ThrowIfNotConnected();
+
+            await _connection.WithWriteLockAsync(async writer =>
+            {
+                await p(new Publisher(writer, _connection.ServerInfo.MaxPayload)).ConfigureAwait(false);
+                if (ShouldAutoFlush)
+                    await writer.FlushAsync().ConfigureAwait(false);
+            }).ConfigureAwait(false);
+        }
+
         public Task<MsgOp> RequestAsync(string subject, string body, CancellationToken cancellationToken = default)
             => RequestAsync(subject, NatsEncoder.GetBytes(body), cancellationToken);
 

--- a/src/testing/IntegrationTests/PubSubTests.cs
+++ b/src/testing/IntegrationTests/PubSubTests.cs
@@ -99,10 +99,14 @@ namespace IntegrationTests
 
             await Context.DelayAsync();
 
-            _client1.PubMany(async p =>
+            _client1.PubMany(p =>
             {
                 p.Pub(subject, messages[0]);
                 p.Pub(subject, Encoding.UTF8.GetBytes(messages[1]));
+            });
+
+            await _client1.PubManyAsync(async p =>
+            {
                 await p.PubAsync(subject, messages[2]);
                 await p.PubAsync(subject, Encoding.UTF8.GetBytes(messages[3]));
             });


### PR DESCRIPTION
This pull request adds PubManyAsync method to NatsClient. The reason is that using async methods in a sync scope is unsafe. Code like that:
```
  _client1.PubMany(async p =>
  {
      p.Pub(subject, messages[0]);
      p.Pub(subject, Encoding.UTF8.GetBytes(messages[1]));
      await p.PubAsync(subject, messages[2]);
      await p.PubAsync(subject, Encoding.UTF8.GetBytes(messages[3]));
  });
```
can lead to an unexpected behaviour. The PubAsync method calls can be executed in another thread outside of the lock and after the Flush call. It depends on TaskScheduler. The correct and safe code will be:
```
  await _client1.PubManyAsync(async p =>
  {
      await p.PubAsync(subject, messages[2]);
      await p.PubAsync(subject, Encoding.UTF8.GetBytes(messages[3]));
  });
```