### PR TITLE
Support standard Microsoft ILogger resolves #84

### DIFF
--- a/src/main/MyNatsClient/LoggerManager.cs
+++ b/src/main/MyNatsClient/LoggerManager.cs
@@ -1,14 +1,35 @@
-﻿using System;
+using System;
 using MyNatsClient.Logging;
+using Microsoft.Extensions.Logging;
 
 namespace MyNatsClient
 {
     public static class LoggerManager
     {
-        public static Func<Type, ILogger> Resolve { get; set; } = _ => NullLogger.Instance;
+        private static Func<Type, MyNatsClient.ILogger> _resolve = _ => NullLogger.Instance;
+
+        public static Func<Type, MyNatsClient.ILogger> Resolve
+        {
+            set { if (value != null) _resolve = value; }
+            get => _resolve;
+        }
 
         public static void ResetToDefaults() => UseNullLogger();
 
         public static void UseNullLogger() => Resolve = _ => NullLogger.Instance;
+
+        public static void UseMicrosoftLogger(Microsoft.Extensions.Logging.ILogger logger)
+        {
+            if (logger != null)
+            {
+                MicrosoftLogger.Instance.SetInternalLogger(logger);
+
+                Resolve = _ => MicrosoftLogger.Instance;
+            }
+            else
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+        }
     }
 }

--- a/src/main/MyNatsClient/Logging/MicrosoftLogger.cs
+++ b/src/main/MyNatsClient/Logging/MicrosoftLogger.cs
@@ -5,11 +5,30 @@ namespace MyNatsClient.Logging
 {
     public class MicrosoftLogger : MyNatsClient.ILogger
     {
-        private static Microsoft.Extensions.Logging.ILogger _logger;
+        private static Microsoft.Extensions.Logging.ILogger _logger = null;
+
+        // System.Lazy is thread-safe by default
+        private static readonly Lazy<MicrosoftLogger> lazy = new(() => new MicrosoftLogger());
+
+        internal static MicrosoftLogger Instance => lazy.Value;
+
+        private MicrosoftLogger() { }
 
         public MicrosoftLogger(Microsoft.Extensions.Logging.ILogger logger)
         {
-            _logger = logger;
+            SetInternalLogger(logger);
+        }
+
+        public void SetInternalLogger(Microsoft.Extensions.Logging.ILogger logger)
+        {
+            if (logger != null)
+            {
+                _logger = logger;
+            }
+            else
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
         }
 
         public void Trace(string message)

--- a/src/main/MyNatsClient/Logging/MicrosoftLogger.cs
+++ b/src/main/MyNatsClient/Logging/MicrosoftLogger.cs
@@ -1,0 +1,40 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace MyNatsClient.Logging
+{
+    public class MicrosoftLogger : MyNatsClient.ILogger
+    {
+        private static Microsoft.Extensions.Logging.ILogger _logger;
+
+        public MicrosoftLogger(Microsoft.Extensions.Logging.ILogger logger)
+        {
+            _logger = logger;
+        }
+
+        public void Trace(string message)
+        {
+            _logger?.LogTrace(message);
+        }
+
+        public void Debug(string message)
+        {
+            _logger?.LogDebug(message);
+        }
+
+        public void Info(string message)
+        {
+            _logger?.LogInformation(message);
+        }
+
+        public void Error(string message)
+        {
+            _logger?.LogError(message);
+        }
+
+        public void Error(string message, Exception ex)
+        {
+            _logger?.LogTrace(ex, message);
+        }
+    }
+}

--- a/src/main/MyNatsClient/MyNatsClient.csproj
+++ b/src/main/MyNatsClient/MyNatsClient.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Add support for the Microsoft.Extensions.Logging.ILogger class that is the official standard interface for loggin in .NET Core 3.x and .NET 5, as per [https://docs.microsoft.com/en-us/dotnet/core/extensions/logging](https://docs.microsoft.com/en-us/dotnet/core/extensions/logging). I believe this is justified as it is the standard interface for logging in .NET going forward, and in turn has its own hooks to support third party loggers like Serilog, etc.

This pull request effectively saves end users some confusion and boilerplate.